### PR TITLE
Exit when poll returned 409 (container stopped)

### DIFF
--- a/ts_sdk/task/__util_task.py
+++ b/ts_sdk/task/__util_task.py
@@ -27,6 +27,8 @@ def poll_task():
     return generate_task_from_reponse(json.load(response))
   except urllib.error.HTTPError as e:
       print({ 'level': 'error', 'message': f'HTTPError: {e.code} for {poll_url}' })
+      if e.code == 409:
+        raise
   except urllib.error.URLError as e:
       print({ 'level': 'error', 'message': f'URLError: {e.reason} for {poll_url}' })
   except Exception as e:

--- a/ts_sdk/task/run_reuse_loop.py
+++ b/ts_sdk/task/run_reuse_loop.py
@@ -76,7 +76,14 @@ if __name__ == '__main__':
   healtcheck_worker(run_state)
 
   while True:
-    task = poll_task()
+    task = None
+
+    try:
+      task = poll_task()
+    except:
+      log.log('Container is stopped - exiting...')
+      break
+
     if task:
       task_id = task.get('id')
       log.log(f'Got new task {task_id}')


### PR DESCRIPTION
We have 2 seconds grace period during ECS instance kill.
We can let the container exit faster by marking the `/poll` response with 409.