### PR TITLE
DI-4112: Raise exception with command response

### DIFF
--- a/ts_sdk/task/__util_command.py
+++ b/ts_sdk/task/__util_command.py
@@ -64,7 +64,7 @@ class Command:
                     elif command_status == "CREATED" or command_status == "PENDING" or command_status == "PROCESSING":
                         continue
                     else:
-                        raise Exception("Command status is " + command_status)
+                        raise Exception(command.get("responseBody"))
 
             if time_elapsed >= ttl_sec:
                 print('TTL for command has expired')


### PR DESCRIPTION
Raise exception when command is in ERROR status and exception message should contain the responseBody of the command